### PR TITLE
Fix for incorrect sorting of projects on bitlocker volumes

### DIFF
--- a/UnityLauncherPro/GetProjects.cs
+++ b/UnityLauncherPro/GetProjects.cs
@@ -146,8 +146,12 @@ namespace UnityLauncherPro
 
             //Console.WriteLine("valueName="+ valueName+"  , projectName =" + projectName);
 
-            // get last modified date from folder
-            DateTime? lastUpdated = folderExists ? Tools.GetLastModifiedTime(projectPath) : null;
+            // get last modified date from most recent date of solution or folder
+            string solutionPath = Path.Combine(projectPath, $"{projectName}.sln");
+            bool solutionExists = File.Exists(solutionPath);
+            DateTime? solutionLastUpdated = solutionExists ? Tools.GetLastModifiedTime(solutionPath) : null;
+            DateTime? folderLastUpdated = folderExists ? Tools.GetLastModifiedTime(projectPath) : null;
+            DateTime? lastUpdated = solutionLastUpdated > folderLastUpdated ? solutionLastUpdated : folderLastUpdated;
 
             // get project version
             string projectVersion = folderExists ? Tools.GetProjectVersion(projectPath) : null;


### PR DESCRIPTION
Projects which are on a bitlocker volume are sorted incorrectly because their folder dates aren't modified when Unity opens the project.
So I added a check for the solution date and use the most recent of the two.
Using the most recent because opening a solution without modifying it updates only the folder date (on normal volumes).