### PR TITLE
Fix for CheckPlasticBranch option being cleared on app restart

### DIFF
--- a/UnityLauncherPro/MainWindow.xaml.cs
+++ b/UnityLauncherPro/MainWindow.xaml.cs
@@ -362,6 +362,7 @@ namespace UnityLauncherPro
                 chkQuitAfterOpen.IsChecked = Properties.Settings.Default.closeAfterProject;
                 chkShowLauncherArgumentsColumn.IsChecked = Properties.Settings.Default.showArgumentsColumn;
                 chkShowGitBranchColumn.IsChecked = Properties.Settings.Default.showGitBranchColumn;
+                chkCheckPlasticBranch.IsChecked = Properties.Settings.Default.checkPlasticBranch;
                 chkShowMissingFolderProjects.IsChecked = Properties.Settings.Default.showProjectsMissingFolder;
                 chkAllowSingleInstanceOnly.IsChecked = Properties.Settings.Default.AllowSingleInstanceOnly;
                 chkAskNameForQuickProject.IsChecked = Properties.Settings.Default.askNameForQuickProject;


### PR DESCRIPTION
The Check Plastic Branch option was cleared each time the app reloads.
This happened because the deserialized value wasn't applied to the checkbox.