### PR TITLE
Project list refresh and startup bug fix

### DIFF
--- a/UnityLauncherPro/MainWindow.xaml.cs
+++ b/UnityLauncherPro/MainWindow.xaml.cs
@@ -670,13 +670,13 @@ namespace UnityLauncherPro
 
         void UpdateUnityInstallationsList()
         {
-            // reset preferred string, if user changed it
+            // Reset preferred string, if user changed it
             //preferredVersion = "none";
 
             unityInstallationsSource = GetUnityInstallations.Scan();
             dataGridUnitys.ItemsSource = unityInstallationsSource;
 
-            // also make dictionary of installed unitys, to search faster
+            // Also make dictionary of installed unitys, to search faster
             unityInstalledVersions.Clear();
 
             for (int i = 0, len = unityInstallationsSource.Count; i < len; i++)
@@ -725,6 +725,7 @@ namespace UnityLauncherPro
                 lstRootFolders.Items.Refresh();
                 Properties.Settings.Default.Save();
                 UpdateUnityInstallationsList();
+                RefreshRecentProjects();
             }
         }
 

--- a/UnityLauncherPro/Tools.cs
+++ b/UnityLauncherPro/Tools.cs
@@ -1420,22 +1420,50 @@ namespace UnityLauncherPro
             return items;
         }
 
-        // https://codereview.stackexchange.com/a/93247
         public static string GetElapsedTime(DateTime datetime)
         {
-            TimeSpan ts = DateTime.Now.Subtract(datetime);
+            TimeSpan elapsed = DateTime.Now - datetime;
 
-            // The trick: make variable contain date and time representing the desired timespan,
-            // having +1 in each date component.
-            DateTime date = DateTime.MinValue + ts;
+            if (elapsed.TotalDays >= 365)
+            {
+                int years = (int)(elapsed.TotalDays / 365);
+                return ProcessPeriod(years, "year");
+            }
+            else if (elapsed.TotalDays >= 30)
+            {
+                int months = (int)(elapsed.TotalDays / 30);
+                return ProcessPeriod(months, "month");
+            }
+            else if (elapsed.TotalDays >= 1)
+            {
+                int days = (int)elapsed.TotalDays;
+                return ProcessPeriod(days, "day", "Yesterday");
+            }
+            else if (elapsed.TotalHours >= 1)
+            {
+                int hours = (int)elapsed.TotalHours;
+                return ProcessPeriod(hours, "hour");
+            }
+            else if (elapsed.TotalMinutes >= 1)
+            {
+                int minutes = (int)elapsed.TotalMinutes;
+                return ProcessPeriod(minutes, "minute");
+            }
+            else if (elapsed.TotalSeconds >= 1)
+            {
+                int seconds = (int)elapsed.TotalSeconds;
+                return ProcessPeriod(seconds, "second");
+            }
 
-            return ProcessPeriod(date.Year - 1, date.Month - 1, "year")
-                   ?? ProcessPeriod(date.Month - 1, date.Day - 1, "month")
-                   ?? ProcessPeriod(date.Day - 1, date.Hour, "day", "Yesterday")
-                   ?? ProcessPeriod(date.Hour, date.Minute, "hour")
-                   ?? ProcessPeriod(date.Minute, date.Second, "minute")
-                   ?? ProcessPeriod(date.Second, 0, "second")
-                   ?? "Right now";
+            return "Right now";
+        }
+
+        private static string ProcessPeriod(int value, string unit, string singular = null)
+        {
+            if (value == 1) return singular ?? $"{value} {unit} ago";
+            else if (value > 1) return $"{value} {unit}s ago";
+
+            return null;
         }
 
         private static string ProcessPeriod(int value, int subValue, string name, string singularName = null)


### PR DESCRIPTION
I encountered some problems and decided to make a fork of it, this is my first pull request so I hope this contribution isn't breaking much

Anyway here's the stuff that I fixed:
- Adding an editor folder in the settings doesn't refresh the project list (and as the result, the versions are still all red even if the editors are added already)
- On startup, GetElapsedTime vomits an error: System.ArgumentOutOfRangeException: 'The added or subtracted value results in an un-representable DateTime.' which doesn't let me to even start the program in the first place

I remade the whole GetElapsedTime because that is the main bug I wanted to fix, case scenario is when the date time desync or goes backwards, the DateTime it's trying to display is a minus time, when that happened, I made it to just say "Right now"