### PR TITLE
Added a Paths.cmd template so users can add their local VisualStudio …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+/Paths.cmd

--- a/Build.cmd
+++ b/Build.cmd
@@ -4,7 +4,14 @@ if exist Debug rd /s /q Debug
 if exist Release rd /s /q Release
 if exist x64 rd /s /q x64
 
-"%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" /p:Configuration=Release
+IF NOT EXIST "Paths.cmd" (
+ECHO Please copy "Paths.cmd.template", enter your Visual Studio path and rename it to "Paths.cmd".
+PAUSE
+GOTO exit
+)
+
+call Paths.cmd
+"%VISUAL_STUDIO_PATH%" /p:Configuration=Release
 
 :exit
 popd

--- a/Build.cmd
+++ b/Build.cmd
@@ -1,18 +1,59 @@
 @echo off
+
+REM Default VS paths to check if no Paths.cmd file exists
+set VISUAL_STUDIO_PATH_0="%programfiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe"
+set VISUAL_STUDIO_PATH_1="%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe"
+set VISUAL_STUDIO_PATH_2="%programfiles(x86)%\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\msbuild.exe"
+set VISUAL_STUDIO_PATH_3="%programfiles(x86)%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe"
+
 pushd "%~dp0"
 if exist Debug rd /s /q Debug
 if exist Release rd /s /q Release
 if exist x64 rd /s /q x64
 
-IF NOT EXIST "Paths.cmd" (
-ECHO Please copy "Paths.cmd.template", enter your Visual Studio path and rename it to "Paths.cmd".
-PAUSE
-GOTO exit
+if exist "Paths.cmd" (
+REM Prefer Paths.cmd as Visual Studio path source if it exists.
+call Paths.cmd
+goto build
+) else (
+REM Otherwise try to auto-detect the Visual Studio path.
+if exist %VISUAL_STUDIO_PATH_0% (
+set VISUAL_STUDIO_PATH=%VISUAL_STUDIO_PATH_0%
+goto build
 )
 
-call Paths.cmd
-"%VISUAL_STUDIO_PATH%" /p:Configuration=Release
+if exist %VISUAL_STUDIO_PATH_1% (
+set VISUAL_STUDIO_PATH=%VISUAL_STUDIO_PATH_1%
+goto build
+)
 
-:exit
+if exist %VISUAL_STUDIO_PATH_2% (
+set VISUAL_STUDIO_PATH=%VISUAL_STUDIO_PATH_2%
+goto build
+)
+
+if exist %VISUAL_STUDIO_PATH_3% (
+set VISUAL_STUDIO_PATH=%VISUAL_STUDIO_PATH_3%
+goto build
+)
+
+REM No default path found. Let the user know what to do.
+echo No Visual Studio installation found. Please configure it manually.
+echo  1. Copy 'Paths.cmd.template'.
+echo  2. Rename it to 'Paths.cmd'.
+echo  3. Enter your Visual Studio path in there.
+echo  4. Restart the build.
+REM Allow disabling pause to support non-interacting build chains.
+if NOT "%~1"=="-no-pause" pause
+goto end
+)
+
+:build
+REM Log the used Vistual Studio version.
+@echo on
+%VISUAL_STUDIO_PATH% /p:Configuration=Release
+@echo off
+
+:end
 popd
 @echo on

--- a/Paths.cmd.template
+++ b/Paths.cmd.template
@@ -1,12 +1,4 @@
 @echo off
-:: Set your Visual Studio path here.
-:: TODO: Make visual studio path auto detection.
-
-:: Enterprise path
-SET VISUAL_STUDIO_PATH=%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe
-
-:: Community path
-::SET VISUAL_STUDIO_PATH=%programfiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe
-
-echo Using Visual Studio path:%VISUAL_STUDIO_PATH%
+REM Set your Visual Studio path here.
+SET VISUAL_STUDIO_PATH="%programfiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe"
 @echo on

--- a/Paths.cmd.template
+++ b/Paths.cmd.template
@@ -1,0 +1,12 @@
+@echo off
+:: Set your Visual Studio path here.
+:: TODO: Make visual studio path auto detection.
+
+:: Enterprise path
+SET VISUAL_STUDIO_PATH=%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe
+
+:: Community path
+::SET VISUAL_STUDIO_PATH=%programfiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\msbuild.exe
+
+echo Using Visual Studio path:%VISUAL_STUDIO_PATH%
+@echo on


### PR DESCRIPTION
…version easily. The old one was locked to 2019 enterprise.
I added this because I am using the VS Community Edition and it seems the enterprise path is committed into the Build.cmd file. My solution allows each user to use their own VS path which allows for more flexibility without polluting the branch with differen VS path commits.