### PR TITLE
Alpha Release Notes: Add support for 6000.0f version and fix bugs in comparison.

### DIFF
--- a/UnityLauncherPro/GetUnityUpdates.cs
+++ b/UnityLauncherPro/GetUnityUpdates.cs
@@ -44,8 +44,12 @@ namespace UnityLauncherPro
             return result;
         }
 
-        public static Updates[] Parse(string items)
+        public static Updates[] Parse(string items, ref List<string> updatesAsString)
         {
+            if (updatesAsString == null)
+                updatesAsString = new List<string>();
+            updatesAsString.Clear();
+
             isDownloadingUnityList = false;
             //SetStatus("Downloading list of Unity versions ... done");
             var receivedList = items.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
@@ -68,6 +72,7 @@ namespace UnityLauncherPro
                     u.ReleaseDate = DateTime.ParseExact(row[3], "MM/dd/yyyy", CultureInfo.InvariantCulture);
                     u.Version = versionTemp;
                     releases.Add(versionTemp, u);
+                    updatesAsString.Add(versionTemp);
                 }
 
                 prevVersion = versionTemp;

--- a/UnityLauncherPro/MainWindow.xaml.cs
+++ b/UnityLauncherPro/MainWindow.xaml.cs
@@ -46,6 +46,7 @@ namespace UnityLauncherPro
         System.Windows.Forms.NotifyIcon notifyIcon;
 
         Updates[] updatesSource;
+        public static List<string> updatesAsStrings;
 
         string _filterString = null;
         bool multiWordSearch = false;
@@ -744,7 +745,7 @@ namespace UnityLauncherPro
             var items = await task;
             //Console.WriteLine("CallGetUnityUpdates=" + items == null);
             if (items == null) return;
-            updatesSource = GetUnityUpdates.Parse(items);
+            updatesSource = GetUnityUpdates.Parse(items, ref updatesAsStrings);
             if (updatesSource == null) return;
             dataGridUpdates.ItemsSource = updatesSource;
         }
@@ -1034,7 +1035,7 @@ namespace UnityLauncherPro
                     var items = await task;
                     if (task.IsCompleted == false || task.IsFaulted == true) return;
                     if (items == null) return;
-                    updatesSource = GetUnityUpdates.Parse(items);
+                    updatesSource = GetUnityUpdates.Parse(items, ref updatesAsStrings);
                     if (updatesSource == null) return;
                     dataGridUpdates.ItemsSource = updatesSource;
                 }

--- a/UnityLauncherPro/Tools.cs
+++ b/UnityLauncherPro/Tools.cs
@@ -593,12 +593,17 @@ namespace UnityLauncherPro
 
             //var url = Tools.GetUnityReleaseURL(version);
             string url = null;
-            if (Properties.Settings.Default.useAlphaReleaseNotes && !version.Contains("6000"))
+            bool noAlphaReleaseNotesPage = version.Contains("6000") && !version.Contains("f");
+            if (Properties.Settings.Default.useAlphaReleaseNotes && !noAlphaReleaseNotesPage)
             {
+                //with the alpha release notes, we want a diff between the 2 versions, but the site just shows all the changes inclusive of from
+                // so we need to compare the currently selected version to the one right after it that is available (installed or not)
+                
                 var closestVersion = Tools.FindNearestVersion(version, MainWindow.unityInstalledVersions.Keys.ToList(), true);
-                if (closestVersion == null) closestVersion = version;
+                var getNextVersionToClosest = closestVersion == null ? null : Tools.FindNearestVersion(version, MainWindow.updatesAsStrings);
+                if (getNextVersionToClosest == null) getNextVersionToClosest = version;
 
-                url = "https://alpha.release-notes.ds.unity3d.com/search?fromVersion=" + closestVersion + "&toVersion=" + version;
+                url = "https://alpha.release-notes.ds.unity3d.com/search?fromVersion=" + getNextVersionToClosest + "&toVersion=" + version;
             }
             else
             {


### PR DESCRIPTION
- Add support for Alpha Release Notes on .f version of 6000 Unity.
- Fix an issue with the alpha release notes website where the list included changes of the closest  version, even though the user wants a strict diff. This is done by adding a string list representation of the updatelist so as to be able to use Tools.FindNearestVersion on that.