### PR TITLE
Add "download editor in browser" button to the upgrade window. 

### DIFF
--- a/UnityLauncherPro/UpgradeWindow.xaml
+++ b/UnityLauncherPro/UpgradeWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:UnityLauncherPro"
         mc:Ignorable="d"
-        Title="Upgrade Project Version" Height="533.165" Width="455" Background="{DynamicResource ThemeDarkestBackground}" MinWidth="319" MinHeight="555" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" HorizontalAlignment="Left" VerticalAlignment="Top" PreviewKeyDown="Window_PreviewKeyDown" ShowInTaskbar="False">
+        Title="Upgrade Project Version" Height="533.165" Width="552" Background="{DynamicResource ThemeDarkestBackground}" MinWidth="319" MinHeight="555" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" HorizontalAlignment="Left" VerticalAlignment="Top" PreviewKeyDown="Window_PreviewKeyDown" ShowInTaskbar="False">
 
     <Grid>
         <StackPanel Orientation="Horizontal">
@@ -15,19 +15,22 @@
             <TextBox MinWidth="100" CaretBrush="#FFE2E2E2" x:Name="txtCurrentPlatform" Background="{DynamicResource ThemeDarkMenuBar}" BorderBrush="{x:Null}" Foreground="#FFC7C7C7" SelectionBrush="#FF003966" BorderThickness="0" Margin="0,16,0,0" UndoLimit="64" Text="Platform" IsReadOnly="True" VerticalAlignment="Top" />
         </StackPanel>
         <Label x:Name="lblAvailableVersions" Content="Available Unity Versions" HorizontalAlignment="Left" Margin="9,94,0,0" VerticalAlignment="Top" Foreground="{DynamicResource ThemeButtonForeground}"/>
-        
+
         <StackPanel Orientation="Horizontal" Margin="9,47,9,0">
-            <Button Style="{StaticResource CustomButton}" x:Name="btnOpenReleasePage" ToolTip="Open Release Notes Page in Browser" Background="{DynamicResource ThemeButtonBackground}" Foreground="#FFC1C1C1" BorderBrush="{x:Null}" HorizontalAlignment="Left" VerticalAlignment="Top" Height="35" Click="BtnOpenReleasePage_Click" Width="125" >
-                <Label Foreground="{DynamicResource ThemeButtonForeground}" Content="_Open Release Notes"/>
+            <Button Style="{StaticResource CustomButton}" x:Name="btnOpenReleasePage" ToolTip="Open Release Notes Page in Browser" Background="{DynamicResource ThemeButtonBackground}" Foreground="#FFC1C1C1" BorderBrush="{x:Null}" VerticalAlignment="Top" Height="35" Click="BtnOpenReleasePage_Click" Width="98" >
+                <Label Foreground="{DynamicResource ThemeButtonForeground}" Content="_Release Notes"/>
             </Button>
-            <Button Style="{StaticResource CustomButton}" x:Name="btnDownload" Background="{DynamicResource ThemeButtonBackground}" Foreground="#FFC1C1C1" Margin="9,0,9,0" BorderBrush="{x:Null}" HorizontalAlignment="Right" VerticalAlignment="Top" Height="35" Click="BtnDownload_Click" Width="125" >
+            <Button Style="{StaticResource CustomButton}" x:Name="btnDownload" Background="{DynamicResource ThemeButtonBackground}" Foreground="#FFC1C1C1" Margin="9,0,0,0" BorderBrush="{x:Null}" HorizontalAlignment="Right" VerticalAlignment="Top" Height="35" Click="BtnDownload_Click" Width="125" >
                 <Label Foreground="{DynamicResource ThemeButtonForeground}" Content="Download in _Browser"/>
+            </Button>
+            <Button Style="{StaticResource CustomButton}" x:Name="btnDownloadEditorInBrwwoser" Background="{DynamicResource ThemeButtonBackground}" Foreground="#FFC1C1C1" Margin="9,0,9,0" BorderBrush="{x:Null}" VerticalAlignment="Top" Height="35" Click="BtnDownloadEditor_Click" Width="159" >
+                <Label Foreground="{DynamicResource ThemeButtonForeground}" Content="Download Editor in _Browser"/>
             </Button>
             <Button Style="{StaticResource CustomButton}" x:Name="btnInstall" Background="{DynamicResource ThemeButtonBackground}" Foreground="#FFC1C1C1" BorderBrush="{x:Null}" HorizontalAlignment="Right" VerticalAlignment="Top" Height="35" Width="125" Click="btnInstall_Click" ToolTip="Downloads Unity web installer into Temp folder and runs it (Root folder path is copied to clipboard)" >
                 <Label Foreground="{DynamicResource ThemeButtonForeground}" Content="_Download &amp; Install"/>
             </Button>
         </StackPanel>
-        
+
         <Button Style="{StaticResource CustomButton}" x:Name="btnCancelUpgrade" Background="{DynamicResource ThemeButtonBackground}" Foreground="#FFC1C1C1" Margin="9,434,0,0" BorderBrush="{x:Null}" HorizontalAlignment="Left" Width="111" VerticalAlignment="Top" Height="51" Click="BtnCancelUpgrade_Click" >
             <Label Foreground="{DynamicResource ThemeButtonForeground}" Content="_Cancel"/>
         </Button>

--- a/UnityLauncherPro/UpgradeWindow.xaml.cs
+++ b/UnityLauncherPro/UpgradeWindow.xaml.cs
@@ -106,6 +106,20 @@ namespace UnityLauncherPro
             Tools.OpenReleaseNotes(txtCurrentVersion.Text);
         }
 
+        
+        private void BtnDownloadEditor_Click(object sender, RoutedEventArgs e)
+        {
+            string url = Tools.GetUnityReleaseURL(txtCurrentVersion.Text);
+            if (string.IsNullOrEmpty(url) == false)
+            {
+                Tools.DownloadInBrowser(url, txtCurrentVersion.Text, true);
+            }
+            else
+            {
+                Console.WriteLine("Failed getting Unity Installer URL for " + txtCurrentVersion.Text);
+            }
+        }
+
         private void BtnDownload_Click(object sender, RoutedEventArgs e)
         {
             string url = Tools.GetUnityReleaseURL(txtCurrentVersion.Text);


### PR DESCRIPTION
Changed  'Open Release Notes' button label to  'Release Notes' to save a bit of horizontal space so that the upgrade window isn't too wide because of the new button.