### PR TITLE
Add a quick "custom" build command

### DIFF
--- a/UnityLauncherPro/MainWindow.xaml
+++ b/UnityLauncherPro/MainWindow.xaml
@@ -227,6 +227,7 @@
                                 <MenuItem Header="Build">
                                     <MenuItem x:Name="menuBatchBuildAndroid" Header="Android" Click="MenuBatchBuildAndroid_Click"/>
                                     <MenuItem x:Name="menuBatchBuildIOS" Header="IOS" Click="MenuBatchBuildIOS_Click"/>
+                                    <MenuItem x:Name="menuBatchBuildCustom" Header="Custom" Click="MenuBatchBuildCustom_Click"/>
                                 </MenuItem>
                                 <MenuItem Header="Tools">
                                     <MenuItem x:Name="menuExcludeFromDefender" Header="Exclude Path From Defender" Click="menuExcludeFromDefender_Click"/>

--- a/UnityLauncherPro/MainWindow.xaml.cs
+++ b/UnityLauncherPro/MainWindow.xaml.cs
@@ -3226,6 +3226,12 @@ namespace UnityLauncherPro
             Tools.BuildProject(proj, Platform.iOS);
         }
 
+        private void MenuBatchBuildCustom_Click(object sender, RoutedEventArgs e)
+        {
+            var proj = GetSelectedProject();
+            Tools.BuildProjectCustom(proj);
+        }
+
         private void ChkCheckPlasticBranch_Checked(object sender, RoutedEventArgs e)
         {
             if (this.IsActive == false) return; // dont run code on window init

--- a/UnityLauncherPro/Tools.cs
+++ b/UnityLauncherPro/Tools.cs
@@ -2104,6 +2104,33 @@ public static class UnityLauncherProTools
 
         }
 
+        public static void BuildProjectCustom(Project proj)
+        {
+            Console.WriteLine("Building " + proj.Title + " (custom)");
+            SetStatus("Build process started: " + DateTime.Now.ToString("HH:mm:ss"));
+
+            // get selected project unity exe path
+            var unityExePath = Tools.GetUnityExePath(proj.Version);
+            if (unityExePath == null) return;
+
+            // create commandline string for building and launch it
+            //var buildcmd = $"\"{unityExePath}\" -quit -batchmode -nographics -projectPath \"{proj.Path}\" -executeMethod \"Builder.BuildAndroid\" -buildTarget android -logFile -";
+            // TODO test without nographics : https://forum.unity.com/threads/batch-build-one-scene-is-black-works-in-normal-file-build.1282823/#post-9456524
+            var buildParams = $" -quit -batchmode -nographics -projectPath \"{proj.Path}\" -executeMethod \"UnityLauncherProToolsCustom.BuildCustom\"";
+            Console.WriteLine("buildcmd= " + buildParams);
+
+            // launch build
+            var proc = Tools.LaunchExe(unityExePath, buildParams);
+
+            // wait for process exit then open output folder
+            proc.Exited += (o, i) =>
+            {
+                SetStatus("Build process finished: " + DateTime.Now.ToString("HH:mm:ss"));
+                // TODO set color based on results
+                SetBuildStatus(Colors.Green);
+            };
+        }
+
         // runs unity SimpleWebServer.exe and launches default Browser into project build/ folder'
         public static void LaunchWebGL(Project proj, string relativeFolder)
         {


### PR DESCRIPTION
Expects a editor script with in the format of:

UnityLauncherProToolsCustom.BuildCustom, e.g.:

```cs
using System.Diagnostics;
using System.IO;
using System.Linq;
using UnityEditor;
using UnityEngine;
public static class UnityLauncherProToolsCustom
{
    [MenuItem("Tools/Build custom")]
    public static void BuildCustom()
    {
        var settings = new BuildPlayerOptions();
        settings.scenes = GetScenes();
        settings.locationPathName = Path.GetFullPath(Path.Combine(Application.dataPath, "..", "..", "..", "Build", PlayerSettings.productName + ".exe"));
        settings.target = EditorUserBuildSettings.activeBuildTarget;
        var report = BuildPipeline.BuildPlayer(settings);
        if (report.summary.result == UnityEditor.Build.Reporting.BuildResult.Succeeded)
            Process.Start(Path.GetDirectoryName(settings.locationPathName));
    }

    static string[] GetScenes()
    {
        return EditorBuildSettings.scenes.Where(scene => scene.enabled).Select(scene => scene.path).ToArray();
    }
}
```