### PR TITLE
Fix missing projects

### DIFF
--- a/UnityLauncherPro/GetProjects.cs
+++ b/UnityLauncherPro/GetProjects.cs
@@ -19,58 +19,18 @@ namespace UnityLauncherPro
         {
             List<Project> projectsFound = new List<Project>();
 
-            var hklm = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
+            VisitProjectsInRegistry
+            (
+                getGitBranch, getPlasticBranch, getArguments, 
+                showMissingFolders, showTargetPlatform , searchGitbranchRecursively , showSRP, 
+                project =>
+            {                
+                projectsFound.Add(project);
 
-            // check each version path
-            for (int i = 0, len = registryPathsToCheck.Length; i < len; i++)
-            {
-                RegistryKey key = hklm.OpenSubKey(registryPathsToCheck[i]);
-
-                if (key == null)
-                {
-                    continue;
-                }
-                else
-                {
-                    //Console.WriteLine("Null registry key at " + registryPathsToCheck[i]);
-                }
-
-                // parse recent project path
-                foreach (var valueName in key.GetValueNames())
-                {
-                    if (valueName.IndexOf("RecentlyUsedProjectPaths-") == 0)
-                    {
-                        string projectPath = "";
-                        // check if binary or not
-                        var valueKind = key.GetValueKind(valueName);
-                        if (valueKind == RegistryValueKind.Binary)
-                        {
-                            byte[] projectPathBytes = (byte[])key.GetValue(valueName);
-                            projectPath = Encoding.UTF8.GetString(projectPathBytes, 0, projectPathBytes.Length - 1);
-                        }
-                        else // should be string then
-                        {
-                            projectPath = (string)key.GetValue(valueName);
-                        }
-
-                        var p = GetProjectInfo(projectPath, getGitBranch, getPlasticBranch, getArguments, showMissingFolders, showTargetPlatform, searchGitbranchRecursively, showSRP);
-                        //Console.WriteLine(projectPath+" "+p.TargetPlatform);
-
-                        // if want to hide project and folder path for screenshot
-                        //p.Title = "Example Project";
-                        //p.Path = "C:/Projects/MyProj";
-
-                        if (p != null)
-                        {
-                            projectsFound.Add(p);
-
-                            // TODO FIXME, this gets called everytime for same projects?
-                            // add found projects to history also (gets added only if its not already there)
-                            Tools.AddProjectToHistory(p.Path);
-                        }
-                    } // valid key
-                } // each key
-            } // for each registry root
+                // TODO FIXME, this gets called everytime for same projects?
+                // add found projects to history also (gets added only if its not already there)
+                Tools.AddProjectToHistory(project.Path);            
+            });
 
             // NOTE those 40 projects should be added to custom list, otherwise they will disappear (since last item is not yet added to our list, until its launched once, so need to launch many projects, to start collecting history..)
             // but then we would have to loop here again..? or add in the loop above..if doesnt exists on list, and the remove extra items from the end
@@ -120,6 +80,61 @@ namespace UnityLauncherPro
             }
             return projectsFound;
         } // Scan()
+
+        // visits each project path stored in the Unity registry, invoking the visitor for each one
+        static void VisitProjectsInRegistry(            
+            bool getGitBranch, bool getPlasticBranch, bool getArguments, 
+            bool showMissingFolders, bool showTargetPlatform , bool searchGitbranchRecursively , bool showSRP, 
+            Action<Project> visitor)
+        {
+            var hklm = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
+
+            // check each version path
+            for (int i = 0, len = registryPathsToCheck.Length; i < len; i++)
+            {
+                RegistryKey key = hklm.OpenSubKey(registryPathsToCheck[i]);
+
+                if (key == null)
+                {
+                    continue;
+                }
+                else
+                {
+                    //Console.WriteLine("Null registry key at " + registryPathsToCheck[i]);
+                }
+
+                // parse recent project path
+                foreach (var valueName in key.GetValueNames())
+                {
+                    if (valueName.IndexOf("RecentlyUsedProjectPaths-") == 0)
+                    {
+                        string projectPath = "";
+                        // check if binary or not
+                        var valueKind = key.GetValueKind(valueName);
+                        if (valueKind == RegistryValueKind.Binary)
+                        {
+                            byte[] projectPathBytes = (byte[])key.GetValue(valueName);
+                            projectPath = Encoding.UTF8.GetString(projectPathBytes, 0, projectPathBytes.Length - 1);
+                        }
+                        else // should be string then
+                        {
+                            projectPath = (string)key.GetValue(valueName);
+                        }
+
+                        var p = GetProjectInfo(projectPath, getGitBranch, getPlasticBranch, getArguments, showMissingFolders, showTargetPlatform, searchGitbranchRecursively, showSRP);
+                        //Console.WriteLine(projectPath+" "+p.TargetPlatform);
+
+                        // if want to hide project and folder path for screenshot
+                        //p.Title = "Example Project";
+                        //p.Path = "C:/Projects/MyProj";
+                        if (p != null)
+                        {
+                            visitor(p);
+                        }
+                    } // valid key
+                } // each key
+            } // for each registry root
+        } // VisitProjectsInRegistry()
 
         static Project GetProjectInfo(string projectPath, bool getGitBranch = false, bool getPlasticBranch = false, bool getArguments = false, bool showMissingFolders = false, bool showTargetPlatform = false, bool searchGitbranchRecursively = false, bool showSRP = false)
         {

--- a/UnityLauncherPro/GetProjects.cs
+++ b/UnityLauncherPro/GetProjects.cs
@@ -19,58 +19,18 @@ namespace UnityLauncherPro
         {
             List<Project> projectsFound = new List<Project>();
 
-            var hklm = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
+            VisitProjectsInRegistry
+            (
+                getGitBranch, getPlasticBranch, getArguments, 
+                showMissingFolders, showTargetPlatform , searchGitbranchRecursively , showSRP, 
+                project =>
+            {                
+                projectsFound.Add(project);
 
-            // check each version path
-            for (int i = 0, len = registryPathsToCheck.Length; i < len; i++)
-            {
-                RegistryKey key = hklm.OpenSubKey(registryPathsToCheck[i]);
-
-                if (key == null)
-                {
-                    continue;
-                }
-                else
-                {
-                    //Console.WriteLine("Null registry key at " + registryPathsToCheck[i]);
-                }
-
-                // parse recent project path
-                foreach (var valueName in key.GetValueNames())
-                {
-                    if (valueName.IndexOf("RecentlyUsedProjectPaths-") == 0)
-                    {
-                        string projectPath = "";
-                        // check if binary or not
-                        var valueKind = key.GetValueKind(valueName);
-                        if (valueKind == RegistryValueKind.Binary)
-                        {
-                            byte[] projectPathBytes = (byte[])key.GetValue(valueName);
-                            projectPath = Encoding.UTF8.GetString(projectPathBytes, 0, projectPathBytes.Length - 1);
-                        }
-                        else // should be string then
-                        {
-                            projectPath = (string)key.GetValue(valueName);
-                        }
-
-                        var p = GetProjectInfo(projectPath, getGitBranch, getPlasticBranch, getArguments, showMissingFolders, showTargetPlatform, searchGitbranchRecursively, showSRP);
-                        //Console.WriteLine(projectPath+" "+p.TargetPlatform);
-
-                        // if want to hide project and folder path for screenshot
-                        //p.Title = "Example Project";
-                        //p.Path = "C:/Projects/MyProj";
-
-                        if (p != null)
-                        {
-                            projectsFound.Add(p);
-
-                            // TODO FIXME, this gets called everytime for same projects?
-                            // add found projects to history also (gets added only if its not already there)
-                            Tools.AddProjectToHistory(p.Path);
-                        }
-                    } // valid key
-                } // each key
-            } // for each registry root
+                // TODO FIXME, this gets called everytime for same projects?
+                // add found projects to history also (gets added only if its not already there)
+                Tools.AddProjectToHistory(project.Path);            
+            });
 
             // NOTE those 40 projects should be added to custom list, otherwise they will disappear (since last item is not yet added to our list, until its launched once, so need to launch many projects, to start collecting history..)
             // but then we would have to loop here again..? or add in the loop above..if doesnt exists on list, and the remove extra items from the end
@@ -120,6 +80,61 @@ namespace UnityLauncherPro
             }
             return projectsFound;
         } // Scan()
+
+        // visits each project stored in the Unity registry, invoking the visitor for each one
+        static void VisitProjectsInRegistry(            
+            bool getGitBranch, bool getPlasticBranch, bool getArguments, 
+            bool showMissingFolders, bool showTargetPlatform , bool searchGitbranchRecursively , bool showSRP, 
+            Action<Project> visitor)
+        {
+            var hklm = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Registry64);
+
+            // check each version path
+            for (int i = 0, len = registryPathsToCheck.Length; i < len; i++)
+            {
+                RegistryKey key = hklm.OpenSubKey(registryPathsToCheck[i]);
+
+                if (key == null)
+                {
+                    continue;
+                }
+                else
+                {
+                    //Console.WriteLine("Null registry key at " + registryPathsToCheck[i]);
+                }
+
+                // parse recent project path
+                foreach (var valueName in key.GetValueNames())
+                {
+                    if (valueName.IndexOf("RecentlyUsedProjectPaths-") == 0)
+                    {
+                        string projectPath = "";
+                        // check if binary or not
+                        var valueKind = key.GetValueKind(valueName);
+                        if (valueKind == RegistryValueKind.Binary)
+                        {
+                            byte[] projectPathBytes = (byte[])key.GetValue(valueName);
+                            projectPath = Encoding.UTF8.GetString(projectPathBytes, 0, projectPathBytes.Length - 1);
+                        }
+                        else // should be string then
+                        {
+                            projectPath = (string)key.GetValue(valueName);
+                        }
+
+                        var p = GetProjectInfo(projectPath, getGitBranch, getPlasticBranch, getArguments, showMissingFolders, showTargetPlatform, searchGitbranchRecursively, showSRP);
+                        //Console.WriteLine(projectPath+" "+p.TargetPlatform);
+
+                        // if want to hide project and folder path for screenshot
+                        //p.Title = "Example Project";
+                        //p.Path = "C:/Projects/MyProj";
+                        if (p != null)
+                        {
+                            visitor(p);
+                        }
+                    } // valid key
+                } // each key
+            } // for each registry root
+        } // VisitProjectsInRegistry()
 
         static Project GetProjectInfo(string projectPath, bool getGitBranch = false, bool getPlasticBranch = false, bool getArguments = false, bool showMissingFolders = false, bool showTargetPlatform = false, bool searchGitbranchRecursively = false, bool showSRP = false)
         {

--- a/UnityLauncherPro/GetProjects.cs
+++ b/UnityLauncherPro/GetProjects.cs
@@ -13,12 +13,31 @@ namespace UnityLauncherPro
         static readonly string[] registryPathsToCheck = new string[] { @"SOFTWARE\Unity Technologies\Unity Editor 5.x", @"SOFTWARE\Unity Technologies\Unity Editor 4.x" };
 
         // convert target platform name into valid buildtarget platform name, NOTE this depends on unity version, now only 2019 and later are supported
-        public static Dictionary<string, string> remapPlatformNames = new Dictionary<string, string> { { "StandaloneWindows64", "Win64" }, { "StandaloneWindows", "Win" }, { "Android", "Android" }, { "WebGL", "WebGL" } };
+        public static Dictionary<string, string> remapPlatformNames = new Dictionary<string, string> { 
+            { "StandaloneWindows64", "Win64" },             
+            { "StandaloneWindows", "Win" }, 
+            { "Android", "Android" }, 
+            { "WebGL", "WebGL" } };
 
         public static List<Project> Scan(bool getGitBranch = false, bool getPlasticBranch = false, bool getArguments = false, bool showMissingFolders = false, bool showTargetPlatform = false, StringCollection AllProjectPaths = null, bool searchGitbranchRecursively = false, bool showSRP = false)
         {
             List<Project> projectsFound = new List<Project>();
 
+            // first, scan projects from unity hub json file
+            VisitProjectsInUnityHubJson
+            (
+                getGitBranch, getPlasticBranch, getArguments, 
+                showMissingFolders, showTargetPlatform , searchGitbranchRecursively , showSRP, 
+                project =>
+            {
+                if (!projectsFound.ContainsProjectWithPath(project.Path))
+                    projectsFound.Add(project);
+
+                // add found projects to history also (gets added only if its not already there)
+                Tools.AddProjectToHistory(project.Path);
+            });
+
+            // then scan projects from registry
             VisitProjectsInRegistry
             (
                 getGitBranch, getPlasticBranch, getArguments, 
@@ -126,6 +145,85 @@ namespace UnityLauncherPro
                 } // each key
             } // for each registry root
         } // VisitProjectsInRegistry()
+
+        private static void VisitProjectsInUnityHubJson(            
+            bool getGitBranch, bool getPlasticBranch, bool getArguments, 
+            bool showMissingFolders, bool showTargetPlatform , bool searchGitbranchRecursively , bool showSRP, 
+            Action<Project> visitor)
+        {
+            string hubProjectsFile = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "UnityHub", "projects-v1.json");
+
+            if (!File.Exists(hubProjectsFile)) 
+                return;
+
+            string json;
+            try { json = File.ReadAllText(hubProjectsFile); }
+            catch { return; }
+
+            int dataIndex = json.IndexOf("\"data\":");
+            if (dataIndex == -1) return;
+
+            // find the opening { of the data object
+            int dataStart = json.IndexOf('{', dataIndex + 7);
+            if (dataStart == -1) return;
+
+            int searchFrom = dataStart + 1;
+            while (true)
+            {
+                // find the start of the next project entry object
+                int entryStart = json.IndexOf('{', searchFrom);
+                if (entryStart == -1) break;
+
+                // find the matching closing }
+                int entryEnd = JsonParser.FindMatchingBrace(json, entryStart);
+                if (entryEnd == -1) break;
+
+                string entry = json.Substring(entryStart, entryEnd - entryStart + 1);
+
+                string projectPath = JsonParser.GetStringValue(entry, "path");
+                if (!string.IsNullOrEmpty(projectPath))
+                {
+                    // unescape JSON backslashes and convert to normal path separators
+                    projectPath = projectPath.Replace(@"\\", @"/");
+
+                    // collect project info from disk, but override with hub json data where its more authoritative
+                    // todo: an optimization could be to only get data from disk that is missing from json, 
+                    // instead of getting all data and then overriding. 
+                    var p = GetProjectInfo(projectPath, getGitBranch, getPlasticBranch, getArguments, showMissingFolders, showTargetPlatform, searchGitbranchRecursively, showSRP);
+                    if (p != null)
+                    {
+                        string title = JsonParser.GetStringValue(entry, "title");
+                        if (!string.IsNullOrEmpty(title)) p.Title = title;
+
+                        // lastModified is a Unix millisecond timestamp
+                        string lastModifiedStr = JsonParser.GetNumberValue(entry, "lastModified");
+                        if (long.TryParse(lastModifiedStr, out long lastModifiedMs))
+                            p.Modified = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddMilliseconds(lastModifiedMs).ToLocalTime();
+
+                        string version = JsonParser.GetStringValue(entry, "version");
+                        if (!string.IsNullOrEmpty(version)) p.Version = version;
+
+                        if (showTargetPlatform)
+                        {
+                            string buildTarget = JsonParser.GetStringValue(entry, "buildTarget");                            
+                            p.TargetPlatform = Tools.GetTargetPlatformFromRaw(buildTarget);                                                        
+                        }
+
+                        if (showSRP)
+                        {
+                            string renderPipeline = JsonParser.GetStringValue(entry, "renderPipeline");
+                            if (!string.IsNullOrEmpty(renderPipeline)) p.SRP = renderPipeline;
+                        }
+
+                        visitor(p);
+                    }
+                }
+
+                searchFrom = entryEnd + 1;
+            }
+        }
 
         private static bool ContainsProjectWithPath(this List<Project> projects, string projectPath)
         {

--- a/UnityLauncherPro/GetProjects.cs
+++ b/UnityLauncherPro/GetProjects.cs
@@ -24,8 +24,9 @@ namespace UnityLauncherPro
                 getGitBranch, getPlasticBranch, getArguments, 
                 showMissingFolders, showTargetPlatform , searchGitbranchRecursively , showSRP, 
                 project =>
-            {                
-                projectsFound.Add(project);
+            {
+                if (!projectsFound.ContainsProjectWithPath(project.Path))
+                    projectsFound.Add(project);
 
                 // TODO FIXME, this gets called everytime for same projects?
                 // add found projects to history also (gets added only if its not already there)
@@ -41,19 +42,9 @@ namespace UnityLauncherPro
                 // iterate custom full projects history
                 foreach (var projectPath in AllProjectPaths)
                 {
-                    // check if registry list contains this path already, then skip it
-                    bool found = false;
-                    for (int i = 0, len = projectsFound.Count; i < len; i++)
-                    {
-                        if (projectsFound[i].Path == projectPath)
-                        {
-                            found = true;
-                            break;
-                        }
-                    }
-
+                    // check if registry list contains this path already
                     // if not found from registry, add to recent projects list
-                    if (found == false)
+                    if (!projectsFound.ContainsProjectWithPath(projectPath))
                     {
                         var p = GetProjectInfo(projectPath, getGitBranch, getPlasticBranch, getArguments, showMissingFolders, showTargetPlatform, searchGitbranchRecursively, showSRP);
                         if (p != null) projectsFound.Add(p);
@@ -82,7 +73,7 @@ namespace UnityLauncherPro
         } // Scan()
 
         // visits each project stored in the Unity registry, invoking the visitor for each one
-        static void VisitProjectsInRegistry(            
+        private static void VisitProjectsInRegistry(            
             bool getGitBranch, bool getPlasticBranch, bool getArguments, 
             bool showMissingFolders, bool showTargetPlatform , bool searchGitbranchRecursively , bool showSRP, 
             Action<Project> visitor)
@@ -135,6 +126,16 @@ namespace UnityLauncherPro
                 } // each key
             } // for each registry root
         } // VisitProjectsInRegistry()
+
+        private static bool ContainsProjectWithPath(this List<Project> projects, string projectPath)
+        {
+            foreach (var p in projects)
+            {
+                if (string.Equals(p.Path, projectPath, StringComparison.OrdinalIgnoreCase)) 
+                    return true;
+            }
+            return false;
+        }
 
         static Project GetProjectInfo(string projectPath, bool getGitBranch = false, bool getPlasticBranch = false, bool getArguments = false, bool showMissingFolders = false, bool showTargetPlatform = false, bool searchGitbranchRecursively = false, bool showSRP = false)
         {

--- a/UnityLauncherPro/Helpers/JsonParser.cs
+++ b/UnityLauncherPro/Helpers/JsonParser.cs
@@ -1,0 +1,41 @@
+namespace UnityLauncherPro
+{
+    internal static class JsonParser
+    {
+        // finds the index of the closing } matching the opening { at startIndex
+        internal static int FindMatchingBrace(string json, int startIndex)
+        {
+            int depth = 0;
+            for (int i = startIndex; i < json.Length; i++)
+            {
+                if (json[i] == '{') depth++;
+                else if (json[i] == '}') { depth--; if (depth == 0) return i; }
+            }
+            return -1;
+        }
+
+        // extracts a JSON string value for the given key
+        internal static string GetStringValue(string json, string key)
+        {
+            int keyIndex = json.IndexOf("\"" + key + "\":");
+            if (keyIndex == -1) return null;
+            int valueStart = json.IndexOf('"', keyIndex + key.Length + 2) + 1;
+            if (valueStart == 0) return null;
+            int valueEnd = json.IndexOf('"', valueStart);
+            if (valueEnd == -1) return null;
+            return json.Substring(valueStart, valueEnd - valueStart);
+        }
+
+        // extracts a JSON number value for the given key (returned as string for flexibility)
+        internal static string GetNumberValue(string json, string key)
+        {
+            int keyIndex = json.IndexOf("\"" + key + "\":");
+            if (keyIndex == -1) return null;
+            int valueStart = keyIndex + key.Length + 3; // skip past "key":
+            while (valueStart < json.Length && json[valueStart] == ' ') valueStart++;
+            int valueEnd = valueStart;
+            while (valueEnd < json.Length && (char.IsDigit(json[valueEnd]) || json[valueEnd] == '-')) valueEnd++;
+            return valueEnd > valueStart ? json.Substring(valueStart, valueEnd - valueStart) : null;
+        }
+    }
+}

--- a/UnityLauncherPro/Tools.cs
+++ b/UnityLauncherPro/Tools.cs
@@ -1626,6 +1626,11 @@ namespace UnityLauncherPro
         {
             var rawPlatformName = GetTargetPlatformRaw(projectPath);
 
+            return GetTargetPlatformFromRaw(rawPlatformName);
+        }
+
+        public static string GetTargetPlatformFromRaw(string rawPlatformName)
+        {
             if (string.IsNullOrEmpty(rawPlatformName) == false && GetProjects.remapPlatformNames.ContainsKey(rawPlatformName))
             {
                 return GetProjects.remapPlatformNames[rawPlatformName];

--- a/UnityLauncherPro/UnityLauncherPro.csproj
+++ b/UnityLauncherPro/UnityLauncherPro.csproj
@@ -107,6 +107,7 @@
     <Compile Include="GetProjects.cs" />
     <Compile Include="GetUnityInstallations.cs" />
     <Compile Include="GetUnityUpdates.cs" />
+    <Compile Include="Helpers\JsonParser.cs" />
     <Compile Include="Helpers\ObservableDictionary.cs" />
     <Compile Include="Helpers\ProcessHandler.cs" />
     <Compile Include="Libraries\ExtractTarGz.cs" />


### PR DESCRIPTION
* Extracted the existing registry scan code in VisitProjectsInRegistry
* Added a new VisitProjectsInUnityHubJson implementation that reads from the new .json file
* Refactored the GetProjects.Scan method to use these two methods above
* The presence of a project in JSON takes priority over the registry (because I imagine people will update the Unity Hub going forward)
* Extracted a ContainsProjectWithPath helper to avoid duplicate checks
* Added a static JsonParser class with some utilities to parse JSON without adding dependencies